### PR TITLE
Fixed XML Types References to WSUS Server (bug #8)

### DIFF
--- a/TypeData/PoshWSUS.Types.ps1xml
+++ b/TypeData/PoshWSUS.Types.ps1xml
@@ -108,12 +108,14 @@
 		<ScriptProperty>
 			<Name>UpdateTitle</Name>
 			<GetScriptBlock>
+				$wsus = Get-PSWSUSServer
 				$wsus.GetUpdate([guid]$This.UpdateId) | Select -Expand Title
 			</GetScriptBlock>
 		</ScriptProperty>
 		<ScriptProperty>
 			<Name>UpdateKB</Name>
 			<GetScriptBlock>
+				$wsus = Get-PSWSUSServer
 				$wsus.GetUpdate([guid]$This.UpdateId) | Select -Expand KnowledgebaseArticles
 			</GetScriptBlock>
 		</ScriptProperty>
@@ -149,6 +151,7 @@
 			<ScriptProperty>
 				<Name>UpdateServerName</Name>
 				<GetScriptBlock>
+					$wsus = Get-PSWSUSServer
 					$wsus.Name
 				</GetScriptBlock>
 			</ScriptProperty>
@@ -178,6 +181,7 @@
 			<ScriptProperty>
 				<Name>UpdateServerName</Name>
 				<GetScriptBlock>
+					$wsus = Get-PSWSUSServer
 					$wsus.Name
 				</GetScriptBlock>
 			</ScriptProperty>
@@ -253,18 +257,21 @@
       <ScriptProperty>
         <Name>ComputerGroup</Name>
         <GetScriptBlock>
+          $wsus = Get-PSWSUSServer
           $Wsus.GetComputerTargetGroup([guid]$This.ComputerTargetGroupId).Name
         </GetScriptBlock>
       </ScriptProperty>
 		<ScriptProperty>
 			<Name>UpdateTitle</Name>
 			<GetScriptBlock>
+				$wsus = Get-PSWSUSServer
 				$wsus.GetUpdate([guid]$This.UpdateId) | Select -Expand Title
 			</GetScriptBlock>
 		</ScriptProperty>
 		<ScriptProperty>
 			<Name>UpdateKB</Name>
 			<GetScriptBlock>
+				$wsus = Get-PSWSUSServer
 				$wsus.GetUpdate([guid]$This.UpdateId) | Select -Expand KnowledgebaseArticles
 			</GetScriptBlock>
 		</ScriptProperty>
@@ -346,6 +353,7 @@
 		<ScriptProperty>
 			<Name>Computer</Name>
 			<GetScriptBlock>
+				$wsus = Get-PSWSUSServer
 				$wsus.GetComputerTarget($This.ComputerTargetID) | Select -Expand FullDomainName
 			</GetScriptBlock>
 		</ScriptProperty>
@@ -363,12 +371,14 @@
 		<ScriptProperty>
 			<Name>UpdateTitle</Name>
 			<GetScriptBlock>
+				$wsus = Get-PSWSUSServer
 				$wsus.GetUpdate([guid]$This.UpdateId) | Select -Expand Title
 			</GetScriptBlock>
 		</ScriptProperty>
 		<ScriptProperty>
 			<Name>UpdateKB</Name>
 			<GetScriptBlock>
+				$wsus = Get-PSWSUSServer
 				$wsus.GetUpdate([guid]$This.UpdateId) | Select -Expand KnowledgebaseArticles
 			</GetScriptBlock>
 		</ScriptProperty>	


### PR DESCRIPTION
Inserted statement '$wsus = Get-PSWSUSServer' each place in the PoshWSUS.Types.ps1xml file to eliminate the blank Computer field as in Get-PSWSUSUpdateSummaryPerClient.  Natively the *.types.ps1xml files don't seem to be aware of any variables besides $this.