### PR TITLE
InstallState(s) -> InstallationState(s)

### DIFF
--- a/Scripts/Get-PSWSUSUpdate.ps1
+++ b/Scripts/Get-PSWSUSUpdate.ps1
@@ -35,7 +35,7 @@ function Get-PSWSUSUpdate {
     .PARAMETER IncludedInstallationState
         Installation states to search for
      
-    .PARAMETER ExcludedInstallState
+    .PARAMETER ExcludedInstallationState
         Installation states to exclude
 
     .PARAMETER FromArrivalDate
@@ -128,7 +128,7 @@ function Get-PSWSUSUpdate {
             [Parameter(ParameterSetName='UpdateScope')]
             [Microsoft.UpdateServices.Administration.UpdateInstallationStates]$IncludedInstallationState,
             [Parameter(ParameterSetName='UpdateScope')]
-            [Microsoft.UpdateServices.Administration.UpdateInstallationStates]$ExcludedInstallState,
+            [Microsoft.UpdateServices.Administration.UpdateInstallationStates]$ExcludedInstallationState,
             [Parameter(ParameterSetName='UpdateScope')]
             [DateTime]$FromArrivalDate,
             [Parameter(ParameterSetName='UpdateScope')]
@@ -156,8 +156,8 @@ function Get-PSWSUSUpdate {
             If ($PSBoundParameters['IncludedInstallationState']) {
                 $UpdateScope.IncludedInstallationStates = $IncludedInstallationState
             }
-            If ($PSBoundParameters['ExcludedInstallState']) {
-                $UpdateScope.ExcludedInstallStates = $ExcludedInstallState
+            If ($PSBoundParameters['ExcludedInstallationState']) {
+                $UpdateScope.ExcludedInstallationStates = $ExcludedInstallationState
             }
             If ($PSBoundParameters['UpdateApprovalAction']) {
                 $UpdateScope.UpdateApprovalActions = $UpdateApprovalAction


### PR DESCRIPTION
Addresses issues #14 and #19 

Have changed `ExcludedInstallState` to `ExcludedInstallationState`, referencing the [MSDN Doco](https://msdn.microsoft.com/en-us/library/microsoft.updateservices.administration.updatescope(v=vs.85).aspx)

p.s. Sorry (not sorry) about the frequency of pull requests. This Hacktoberfest event has got me wanting to look into the issues listed on PowerShell repos and figured it a good idea to cut my teeth on modules I know and use regularly; at least two of yours being at the top of that list.