### PR TITLE
Adding and/or adjusting warning to run Connect-PSWSUSServer

### DIFF
--- a/Scripts/Add-PSWSUSClientToGroup.ps1
+++ b/Scripts/Add-PSWSUSClientToGroup.ps1
@@ -71,7 +71,7 @@ function Add-PSWSUSClientToGroup {
             }#endif
             else
             {
-                Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+                Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
                 Break
             }
         } Else {

--- a/Scripts/Add-PSWSUSClientToGroup.ps1
+++ b/Scripts/Add-PSWSUSClientToGroup.ps1
@@ -50,21 +50,29 @@ function Add-PSWSUSClientToGroup {
             $Client = $Computername
         }
         If ($client) {
-            #Get group object
-            Write-Verbose "Retrieving group"
-            $targetgroup = $wsus.getcomputertargetgroups() | Where {
-                $_.Name -eq $group
-            }
-            If (-Not $targetgroup) {
-                Write-Error "Group $group does not exist in WSUS!"
-                Break
-            }
-            ForEach ($C in $Client) {    
-                #Add client to group
-                Write-Verbose ("Adding {0} to {1}" -f $c.fulldomainname,$Group)
-                If ($pscmdlet.ShouldProcess($($c.fulldomainname))) {
-                    $targetgroup.AddComputerTarget($c)
+            if($wsus)
+            {
+                #Get group object
+                Write-Verbose "Retrieving group"
+                $targetgroup = $wsus.getcomputertargetgroups() | Where {
+                    $_.Name -eq $group
                 }
+                If (-Not $targetgroup) {
+                    Write-Error "Group $group does not exist in WSUS!"
+                    Break
+                }
+                ForEach ($C in $Client) {    
+                    #Add client to group
+                    Write-Verbose ("Adding {0} to {1}" -f $c.fulldomainname,$Group)
+                    If ($pscmdlet.ShouldProcess($($c.fulldomainname))) {
+                        $targetgroup.AddComputerTarget($c)
+                    }
+                }
+            }#endif
+            else
+            {
+                Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+                Break
             }
         } Else {
             Write-Warning ("{0}: Unable to locate!`n{1}" -f $Computername,$_.Exception.Message)

--- a/Scripts/Connect-PSWSUSDatabaseServer.ps1
+++ b/Scripts/Connect-PSWSUSDatabaseServer.ps1
@@ -26,6 +26,14 @@ Function Connect-PSWSUSDatabaseServer {
                 ValueFromPipeline = $False)]
                 [switch]$Passthru
             )
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process { 
         #Create database connection
         Write-Verbose "Creating the database connection to the database hosting WSUS"

--- a/Scripts/Connect-PSWSUSDatabaseServer.ps1
+++ b/Scripts/Connect-PSWSUSDatabaseServer.ps1
@@ -30,7 +30,7 @@ Function Connect-PSWSUSDatabaseServer {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Export-PSWSUSMetaData.ps1
+++ b/Scripts/Export-PSWSUSMetaData.ps1
@@ -42,7 +42,7 @@ function Export-PSWSUSMetaData {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Export-PSWSUSMetaData.ps1
+++ b/Scripts/Export-PSWSUSMetaData.ps1
@@ -38,6 +38,14 @@ function Export-PSWSUSMetaData {
             [Parameter(Mandatory=$True,Position = 1,ValueFromPipeline = $True)]
             [string]$LogName                                                            
         )
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         If ($pscmdlet.ShouldProcess($FileName,"Export MetaData")) {
             Try {

--- a/Scripts/Get-PSWSUSCategory.ps1
+++ b/Scripts/Get-PSWSUSCategory.ps1
@@ -39,6 +39,14 @@ function Get-PSWSUSCategory {
             ValueFromPipeline = $True)]
             [string]$Title            
     ) 
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         If ($PSBoundParameters['Id']) {
             $Wsus.GetUpdateCategory($Id)

--- a/Scripts/Get-PSWSUSCategory.ps1
+++ b/Scripts/Get-PSWSUSCategory.ps1
@@ -43,7 +43,7 @@ function Get-PSWSUSCategory {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSChildServer.ps1
+++ b/Scripts/Get-PSWSUSChildServer.ps1
@@ -21,6 +21,14 @@ function Get-PSWSUSChildServer {
     #> 
     [cmdletbinding()]  
     Param ()
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process { 
         #Gather all child servers in WSUS    
         $wsus.GetChildServers()

--- a/Scripts/Get-PSWSUSChildServer.ps1
+++ b/Scripts/Get-PSWSUSChildServer.ps1
@@ -25,7 +25,7 @@ function Get-PSWSUSChildServer {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSClassification.ps1
+++ b/Scripts/Get-PSWSUSClassification.ps1
@@ -27,7 +27,7 @@ Function Get-PSWSUSClassification {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSClassification.ps1
+++ b/Scripts/Get-PSWSUSClassification.ps1
@@ -23,6 +23,14 @@ Function Get-PSWSUSClassification {
     #> 
     [cmdletbinding()]  
     Param()
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         $wsus.GetUpdateClassifications()        
     }

--- a/Scripts/Get-PSWSUSClient.ps1
+++ b/Scripts/Get-PSWSUSClient.ps1
@@ -142,7 +142,7 @@ function Get-PSWSUSClient {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSClient.ps1
+++ b/Scripts/Get-PSWSUSClient.ps1
@@ -103,39 +103,47 @@ function Get-PSWSUSClient {
             [switch]$IncludeDownstreamComputerTargets
         )
     Begin {                
-        $ErrorActionPreference = 'Stop'  
-        If ($PSCmdlet.ParameterSetName -eq 'ComputerScope') {
-            $ComputerScope = New-Object Microsoft.UpdateServices.Administration.ComputerTargetScope  
-            If ($PSBoundParameters['IncludedInstallationState']) {
-                $ComputerScope.IncludedInstallationStates = $IncludedInstallationState
+        if($wsus)
+        {
+            $ErrorActionPreference = 'Stop'  
+            If ($PSCmdlet.ParameterSetName -eq 'ComputerScope') {
+                $ComputerScope = New-Object Microsoft.UpdateServices.Administration.ComputerTargetScope  
+                If ($PSBoundParameters['IncludedInstallationState']) {
+                    $ComputerScope.IncludedInstallationStates = $IncludedInstallationState
+                }
+                If ($PSBoundParameters['ExcludedInstallState']) {
+                    $ComputerScope.ExcludedInstallationStates = $ExcludedInstallState
+                }
+                If ($PSBoundParameters['FromLastStatusTime']) {
+                    $ComputerScope.FromLastReportedStatusTime = $FromLastStatusTime
+                }
+                If ($PSBoundParameters['ToLastStatusTime']) {
+                    $ComputerScope.ToLastReportedStatusTime = $ToLastStatusTime
+                }
+                If ($PSBoundParameters['FromLastSyncTime']) {
+                    $ComputerScope.FromLastSyncTime = $FromLastSyncTime
+                }
+                If ($PSBoundParameters['ToLastSyncTime']) {
+                    $ComputerScope.ToLastSyncTime = $ToLastSyncTime
+                }
+                If ($PSBoundParameters['IncludeSubGroups']) {
+                    $ComputerScope.IncludeSubgroups = $IncludeSubGroups
+                }
+                If ($PSBoundParameters['OSFamily']) {
+                    $ComputerScope.OSFamily = $OSFamily
+                }
+                If ($PSBoundParameters['IncludeDownstreamComputerTargets']) {
+                    $ComputerScope.IncludeDownstreamComputerTargets = $IncludeDownstreamComputerTargets
+                }
+                If ($PSBoundParameters['ComputerTargetGroups']) {
+                    [void]$ComputerScope.ComputerTargetGroups.AddRange($ComputerTargetGroups)
+                }
             }
-            If ($PSBoundParameters['ExcludedInstallState']) {
-                $ComputerScope.ExcludedInstallationStates = $ExcludedInstallState
-            }
-            If ($PSBoundParameters['FromLastStatusTime']) {
-                $ComputerScope.FromLastReportedStatusTime = $FromLastStatusTime
-            }
-            If ($PSBoundParameters['ToLastStatusTime']) {
-                $ComputerScope.ToLastReportedStatusTime = $ToLastStatusTime
-            }
-            If ($PSBoundParameters['FromLastSyncTime']) {
-                $ComputerScope.FromLastSyncTime = $FromLastSyncTime
-            }
-            If ($PSBoundParameters['ToLastSyncTime']) {
-                $ComputerScope.ToLastSyncTime = $ToLastSyncTime
-            }
-            If ($PSBoundParameters['IncludeSubGroups']) {
-                $ComputerScope.IncludeSubgroups = $IncludeSubGroups
-            }
-            If ($PSBoundParameters['OSFamily']) {
-                $ComputerScope.OSFamily = $OSFamily
-            }
-            If ($PSBoundParameters['IncludeDownstreamComputerTargets']) {
-                $ComputerScope.IncludeDownstreamComputerTargets = $IncludeDownstreamComputerTargets
-            }
-            If ($PSBoundParameters['ComputerTargetGroups']) {
-                [void]$ComputerScope.ComputerTargetGroups.AddRange($ComputerTargetGroups)
-            }
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
         }
     }
     Process {

--- a/Scripts/Get-PSWSUSClientsInGroup.ps1
+++ b/Scripts/Get-PSWSUSClientsInGroup.ps1
@@ -45,7 +45,7 @@ function Get-PSWSUSClientsInGroup {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSClientsInGroup.ps1
+++ b/Scripts/Get-PSWSUSClientsInGroup.ps1
@@ -41,6 +41,14 @@ function Get-PSWSUSClientsInGroup {
             Position = 1)]
             [string]$Id                           
             )
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {                                    
         If ($PSBoundParameters['id']) {     
             ($wsus.GetComputerTargetGroups() | Where {

--- a/Scripts/Get-PSWSUSConfig.ps1
+++ b/Scripts/Get-PSWSUSConfig.ps1
@@ -40,7 +40,7 @@ function Get-PSWSUSConfig {
         if($wsus){}#endif
         else
         {
-            Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSConfigEnabledUpdateLanguages.ps1
+++ b/Scripts/Get-PSWSUSConfigEnabledUpdateLanguages.ps1
@@ -33,7 +33,7 @@ function Get-PSWSUSConfigEnabledUpdateLanguages {
     {
         if( -NOT $wsus)
         {
-            Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSConfigProxyServer.ps1
+++ b/Scripts/Get-PSWSUSConfigProxyServer.ps1
@@ -29,7 +29,7 @@ function Get-PSWSUSConfigProxyServer {
 
     Begin
     {
-        if($wsus)
+        if(-not $wsus)
         {
             Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
             Break

--- a/Scripts/Get-PSWSUSConfigProxyServer.ps1
+++ b/Scripts/Get-PSWSUSConfigProxyServer.ps1
@@ -31,7 +31,7 @@ function Get-PSWSUSConfigProxyServer {
     {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSConfigSupportedUpdateLanguages.ps1
+++ b/Scripts/Get-PSWSUSConfigSupportedUpdateLanguages.ps1
@@ -41,7 +41,7 @@ function Get-PSWSUSConfigSupportedUpdateLanguages {
     )
     if(-not $wsus)
     {
-        Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+        Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
         Break
     } 
     Write-Verbose "Getting WSUS Supported Update Languages"

--- a/Scripts/Get-PSWSUSConfigSupportedUpdateLanguages.ps1
+++ b/Scripts/Get-PSWSUSConfigSupportedUpdateLanguages.ps1
@@ -39,7 +39,7 @@ function Get-PSWSUSConfigSupportedUpdateLanguages {
     Param
     (
     )
-    if($wsus)
+    if(-not $wsus)
     {
         Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
         Break

--- a/Scripts/Get-PSWSUSConfigSyncSchedule.ps1
+++ b/Scripts/Get-PSWSUSConfigSyncSchedule.ps1
@@ -33,7 +33,7 @@ function Get-PSWSUSConfigSyncSchedule {
 
         if(-NOT $wsus)
         {
-            Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
         Write-Verbose "Getting WSUS update source configuration"

--- a/Scripts/Get-PSWSUSConfigSyncUpdateCategories.ps1
+++ b/Scripts/Get-PSWSUSConfigSyncUpdateCategories.ps1
@@ -32,7 +32,7 @@ function Get-PSWSUSConfigSyncUpdateCategories {
     Param () 
         if (-NOT $wsus)
         {
-            Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
         $wsus.GetSubscription().GetUpdateCategories()

--- a/Scripts/Get-PSWSUSConfigSyncUpdateClassifications.ps1
+++ b/Scripts/Get-PSWSUSConfigSyncUpdateClassifications.ps1
@@ -28,7 +28,7 @@ function Get-PSWSUSConfigSyncUpdateClassifications {
     Param()
 
 
-    if ($wsus)
+    if (-not $wsus)
     {
         Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
         Break

--- a/Scripts/Get-PSWSUSConfigSyncUpdateClassifications.ps1
+++ b/Scripts/Get-PSWSUSConfigSyncUpdateClassifications.ps1
@@ -30,7 +30,7 @@ function Get-PSWSUSConfigSyncUpdateClassifications {
 
     if (-not $wsus)
     {
-        Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+        Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
         Break
     }
     $wsus.GetSubscription().GetUpdateClassifications()

--- a/Scripts/Get-PSWSUSConfigUpdateFiles.ps1
+++ b/Scripts/Get-PSWSUSConfigUpdateFiles.ps1
@@ -35,7 +35,7 @@ function Get-PSWSUSConfigUpdateFiles {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSConfigUpdateSource.ps1
+++ b/Scripts/Get-PSWSUSConfigUpdateSource.ps1
@@ -25,7 +25,7 @@ function Get-PSWSUSConfigUpdateSource {
     [CmdletBinding()]
     Param()
 
-        if($wsus)
+        if(-not $wsus)
         {
             Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
             Break

--- a/Scripts/Get-PSWSUSConfigUpdateSource.ps1
+++ b/Scripts/Get-PSWSUSConfigUpdateSource.ps1
@@ -27,7 +27,7 @@ function Get-PSWSUSConfigUpdateSource {
 
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
 

--- a/Scripts/Get-PSWSUSConfiguration.ps1
+++ b/Scripts/Get-PSWSUSConfiguration.ps1
@@ -40,7 +40,7 @@ function Get-PSWSUSConfiguration {
         if($wsus){}#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSContentDownloadProgress.ps1
+++ b/Scripts/Get-PSWSUSContentDownloadProgress.ps1
@@ -24,6 +24,14 @@ function Get-PSWSUSContentDownloadProgress {
     #> 
     [cmdletbinding()]  
     Param ()
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         #Gather all child servers in WSUS    
         $wsus.GetContentDownloadProgress()       

--- a/Scripts/Get-PSWSUSContentDownloadProgress.ps1
+++ b/Scripts/Get-PSWSUSContentDownloadProgress.ps1
@@ -28,7 +28,7 @@ function Get-PSWSUSContentDownloadProgress {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSCurrentUserRole.ps1
+++ b/Scripts/Get-PSWSUSCurrentUserRole.ps1
@@ -21,6 +21,14 @@ function Get-PSWSUSCurrentUserRole {
     #> 
     [cmdletbinding()]  
     Param () 
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         #Return the current user role   
         $wsus.GetCurrentUserRole()

--- a/Scripts/Get-PSWSUSCurrentUserRole.ps1
+++ b/Scripts/Get-PSWSUSCurrentUserRole.ps1
@@ -25,7 +25,7 @@ function Get-PSWSUSCurrentUserRole {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSDatabaseConfig.ps1
+++ b/Scripts/Get-PSWSUSDatabaseConfig.ps1
@@ -24,7 +24,7 @@ function Get-PSWSUSDatabaseConfig {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSDatabaseConfig.ps1
+++ b/Scripts/Get-PSWSUSDatabaseConfig.ps1
@@ -20,6 +20,14 @@ function Get-PSWSUSDatabaseConfig {
     #> 
     [cmdletbinding()]  
     Param () 
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         $wsus.GetDatabaseConfiguration()      
     }

--- a/Scripts/Get-PSWSUSDownstreamServer.ps1
+++ b/Scripts/Get-PSWSUSDownstreamServer.ps1
@@ -21,6 +21,14 @@ function Get-PSWSUSDownstreamServer {
     #> 
     [cmdletbinding()]  
     Param () 
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         #Gather all child servers in WSUS    
         $wsus.GetDownstreamServers()

--- a/Scripts/Get-PSWSUSDownstreamServer.ps1
+++ b/Scripts/Get-PSWSUSDownstreamServer.ps1
@@ -25,7 +25,7 @@ function Get-PSWSUSDownstreamServer {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSEmailConfig.ps1
+++ b/Scripts/Get-PSWSUSEmailConfig.ps1
@@ -40,7 +40,15 @@ function Get-PSWSUSEmailConfig {
                 [switch]$SendTestEmail                   
                 )     
     Begin {              
-        $email = $wsus.GetEmailNotificationConfiguration()    
+        if($wsus)
+        {
+            $email = $wsus.GetEmailNotificationConfiguration()
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
     }
     Process {
         If ($PSBoundParameters['SendTestEmail']) {

--- a/Scripts/Get-PSWSUSEmailConfig.ps1
+++ b/Scripts/Get-PSWSUSEmailConfig.ps1
@@ -46,7 +46,7 @@ function Get-PSWSUSEmailConfig {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSEnabledUpdateLanguages.ps1
+++ b/Scripts/Get-PSWSUSEnabledUpdateLanguages.ps1
@@ -37,7 +37,7 @@ function Get-PSWSUSEnabledUpdateLanguages {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSEvent.ps1
+++ b/Scripts/Get-PSWSUSEvent.ps1
@@ -21,6 +21,13 @@ function Get-PSWSUSEvent {
     #> 
     [cmdletbinding()]  
     Param () 
+    
+    if(-not $wsus)
+    {
+        Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+        Break
+    }
+
     $Subscription = $wsus.GetSubscription()
     $Subscription.GetEventHistory() | ForEach {
         $_ | Add-Member -MemberType NoteProperty -Name EventID -Value ($_.Row.EventID) -PassThru |

--- a/Scripts/Get-PSWSUSEvent.ps1
+++ b/Scripts/Get-PSWSUSEvent.ps1
@@ -24,7 +24,7 @@ function Get-PSWSUSEvent {
     
     if(-not $wsus)
     {
-        Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+        Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
         Break
     }
 

--- a/Scripts/Get-PSWSUSGroup.ps1
+++ b/Scripts/Get-PSWSUSGroup.ps1
@@ -47,6 +47,14 @@ function Get-PSWSUSGroup {
             [Parameter(ParameterSetName = 'Id')]
             [string]$Id            
             )
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {            
         Switch ($PSCmdlet.ParameterSetName) {
             'Name' {

--- a/Scripts/Get-PSWSUSGroup.ps1
+++ b/Scripts/Get-PSWSUSGroup.ps1
@@ -51,7 +51,7 @@ function Get-PSWSUSGroup {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSInstallApprovalRule.ps1
+++ b/Scripts/Get-PSWSUSInstallApprovalRule.ps1
@@ -23,6 +23,14 @@ This command will display the configuration information for the WSUS connection 
 #> 
 [cmdletbinding()]  
     Param()
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         $wsus.GetInstallApprovalRules()        
     }

--- a/Scripts/Get-PSWSUSInstallApprovalRule.ps1
+++ b/Scripts/Get-PSWSUSInstallApprovalRule.ps1
@@ -27,7 +27,7 @@ This command will display the configuration information for the WSUS connection 
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSInstallableItem.ps1
+++ b/Scripts/Get-PSWSUSInstallableItem.ps1
@@ -108,12 +108,20 @@ function Get-PSWSUSInstallableItem {
                 $patches = $inputobject    
             }                
             "name" {
-                Write-Verbose "Using 'String' set name"
-                #Search for updates
-                Write-Verbose "Searching for update/s"
-                $patches = @($wsus.SearchUpdates($UpdateName))
-                If ($patches -eq 0) {
-                    Write-Error "Update $update could not be found in WSUS!"
+                if($wsus)
+                {
+                    Write-Verbose "Using 'String' set name"
+                    #Search for updates
+                    Write-Verbose "Searching for update/s"
+                    $patches = @($wsus.SearchUpdates($UpdateName))
+                    If ($patches -eq 0) {
+                        Write-Error "Update $update could not be found in WSUS!"
+                        Break
+                    }
+                }#endif
+                else
+                {
+                    Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
                     Break
                 }                     
             }

--- a/Scripts/Get-PSWSUSInstallableItem.ps1
+++ b/Scripts/Get-PSWSUSInstallableItem.ps1
@@ -121,7 +121,7 @@ function Get-PSWSUSInstallableItem {
                 }#endif
                 else
                 {
-                    Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+                    Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
                     Break
                 }                     
             }

--- a/Scripts/Get-PSWSUSProxyServer.ps1
+++ b/Scripts/Get-PSWSUSProxyServer.ps1
@@ -35,7 +35,7 @@ function Get-PSWSUSProxyServer {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSServer.ps1
+++ b/Scripts/Get-PSWSUSServer.ps1
@@ -42,7 +42,7 @@ function Get-PSWSUSServer {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSServer.ps1
+++ b/Scripts/Get-PSWSUSServer.ps1
@@ -38,6 +38,14 @@ function Get-PSWSUSServer {
                 ValueFromPipeline = $False)]
                 [switch]$ShowConfiguration                     
                 )                    
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {                
         If ($PSBoundParameters['ShowConfiguration']) {
             $wsus.GetConfiguration()

--- a/Scripts/Get-PSWSUSStatus.ps1
+++ b/Scripts/Get-PSWSUSStatus.ps1
@@ -21,6 +21,14 @@ function Get-PSWSUSStatus {
     #> 
     [cmdletbinding()]  
     Param () 
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         $wsus.getstatus()      
     }

--- a/Scripts/Get-PSWSUSStatus.ps1
+++ b/Scripts/Get-PSWSUSStatus.ps1
@@ -25,7 +25,7 @@ function Get-PSWSUSStatus {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSSubscription.ps1
+++ b/Scripts/Get-PSWSUSSubscription.ps1
@@ -27,7 +27,7 @@ function Get-PSWSUSSubscription {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSSubscription.ps1
+++ b/Scripts/Get-PSWSUSSubscription.ps1
@@ -23,6 +23,14 @@ function Get-PSWSUSSubscription {
     #> 
     [cmdletbinding()]  
     Param () 
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         $wsus.GetSubscription()     
     }

--- a/Scripts/Get-PSWSUSSupportedUpdateLanguages.ps1
+++ b/Scripts/Get-PSWSUSSupportedUpdateLanguages.ps1
@@ -48,7 +48,7 @@ function Get-PSWSUSSupportedUpdateLanguages {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSSyncEvent.ps1
+++ b/Scripts/Get-PSWSUSSyncEvent.ps1
@@ -28,7 +28,7 @@ function Get-PSWSUSSyncEvent {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSSyncEvent.ps1
+++ b/Scripts/Get-PSWSUSSyncEvent.ps1
@@ -22,7 +22,15 @@ function Get-PSWSUSSyncEvent {
     [cmdletbinding()]  
     Param () 
     Begin {
-        $sub = $wsus.GetSubscription()
+        if($wsus)
+        {
+            $sub = $wsus.GetSubscription()
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
     }
     Process {
         $sub.GetEventHistory()      

--- a/Scripts/Get-PSWSUSSyncHistory.ps1
+++ b/Scripts/Get-PSWSUSSyncHistory.ps1
@@ -21,6 +21,15 @@ function Get-PSWSUSSyncHistory {
     #> 
     [cmdletbinding()]  
     Param () 
-    $Subscription = $wsus.GetSubscription()
-    $Subscription.GetSynchronizationHistory()     
+    
+    if($wsus)
+    {
+        $Subscription = $wsus.GetSubscription()
+        $Subscription.GetSynchronizationHistory()
+    }#endif
+    else
+    {
+        Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+        Break
+    }
 } 

--- a/Scripts/Get-PSWSUSSyncHistory.ps1
+++ b/Scripts/Get-PSWSUSSyncHistory.ps1
@@ -29,7 +29,7 @@ function Get-PSWSUSSyncHistory {
     }#endif
     else
     {
-        Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+        Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
         Break
     }
 } 

--- a/Scripts/Get-PSWSUSSyncProgress.ps1
+++ b/Scripts/Get-PSWSUSSyncProgress.ps1
@@ -31,7 +31,7 @@ function Get-PSWSUSSyncProgress {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }   
     }

--- a/Scripts/Get-PSWSUSSyncProgress.ps1
+++ b/Scripts/Get-PSWSUSSyncProgress.ps1
@@ -25,7 +25,15 @@ function Get-PSWSUSSyncProgress {
     [cmdletbinding()]  
     Param ()
     Begin {    
-        $sub = $wsus.GetSubscription()    
+        if($wsus)
+        {
+            $sub = $wsus.GetSubscription() 
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }   
     }
     Process {
         #Gather all child servers in WSUS    

--- a/Scripts/Get-PSWSUSSyncSchedule.ps1
+++ b/Scripts/Get-PSWSUSSyncSchedule.ps1
@@ -37,7 +37,7 @@ function Get-PSWSUSSyncSchedule {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSSyncUpdateCategories.ps1
+++ b/Scripts/Get-PSWSUSSyncUpdateCategories.ps1
@@ -31,7 +31,7 @@ function Get-PoshWSUSSyncUpdateCategories {
         }
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSSyncUpdateClassifications.ps1
+++ b/Scripts/Get-PSWSUSSyncUpdateClassifications.ps1
@@ -30,7 +30,7 @@ function Get-PoshWSUSSyncUpdateClassifications {
         }
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSUpdate.ps1
+++ b/Scripts/Get-PSWSUSUpdate.ps1
@@ -147,67 +147,75 @@ function Get-PSWSUSUpdate {
             [Microsoft.UpdateServices.Internal.BaseApi.UpdateClassification[]]$Classification
         )
     Begin {                
-        $ErrorActionPreference = 'stop'  
-        If ($PSCmdlet.ParameterSetName -eq 'UpdateScope') {
-            $UpdateScope = New-Object Microsoft.UpdateServices.Administration.UpdateScope  
-            If ($PSBoundParameters['ApprovedState']) {
-                $UpdateScope.ApprovedStates = $ApprovedState
-            }
-            If ($PSBoundParameters['IncludedInstallationState']) {
-                $UpdateScope.IncludedInstallationStates = $IncludedInstallationState
-            }
-            If ($PSBoundParameters['ExcludedInstallationState']) {
-                $UpdateScope.ExcludedInstallationStates = $ExcludedInstallationState
-            }
-            If ($PSBoundParameters['UpdateApprovalAction']) {
-                $UpdateScope.UpdateApprovalActions = $UpdateApprovalAction
-            }
-            If ($PSBoundParameters['UpdateSource']) {
-                $UpdateScope.UpdateSources = $UpdateSource
-            }
-            If ($PSBoundParameters['UpdateType']) {
-                $UpdateScope.UpdateTypes = $UpdateType
-            }
-            If ($PSBoundParameters['FromArrivalDate']) {
-                $UpdateScope.FromArrivalDate = $FromArrivalDate
-            }
-            If ($PSBoundParameters['ToArrivalDate']) {
-                $UpdateScope.ToArrivalDate = $ToArrivalDate
-            }
-            If ($PSBoundParameters['FromCreationDate']) {
-                $UpdateScope.FromCreationDate = $FromCreationDate
-            }
-            If ($PSBoundParameters['ToCreationDate']) {
-                $UpdateScope.ToCreationDate = $ToCreationDate
-            }
-            If ($PSBoundParameters['ExcludeOptionalUpdates']) {
-                $UpdateScope.ExcludeOptionalUpdates = $ExcludeOptionalUpdates
-            }
-            If ($PSBoundParameters['IsWsusInfrastructureUpdate']) {
-                $UpdateScope.IsWsusInfrastructureUpdate = $IsWsusInfrastructureUpdate
-            }
-            If ($PSBoundParameters['Category']) {
-                [void]$UpdateScope.Categories.AddRange($Category)
-            }
-            If ($PSBoundParameters['Classification']) {
-                [void]$UpdateScope.Classifications.AddRange($Classification)
-            }
-            If ($PSBoundParameters['IncludeText']) {
-                $UpdateScope.TextIncludes = $IncludeText
-            }
-            If ($PSBoundParameters['ExcludeText']) {
-                $UpdateScope.TextNotIncludes = $ExcludeText
-            }
-            If ($PSBoundParameters['ComputerTargetGroups']) {
-                $Groups = @{}
-                $Wsus.GetComputerTargetGroups() | ForEach {                    
-                    $Groups[$_.Name]=$_
+        if($wsus)
+        {
+            $ErrorActionPreference = 'stop'  
+            If ($PSCmdlet.ParameterSetName -eq 'UpdateScope') {
+                $UpdateScope = New-Object Microsoft.UpdateServices.Administration.UpdateScope  
+                If ($PSBoundParameters['ApprovedState']) {
+                    $UpdateScope.ApprovedStates = $ApprovedState
                 }
-                ForEach ($Group in $ComputerTargetGroups) {
-                    Write-Verbose "Adding Target Group: $($Group)"
-                    [void]$UpdateScope.ApprovedComputerTargetGroups.Add($Groups[$Group])
+                If ($PSBoundParameters['IncludedInstallationState']) {
+                    $UpdateScope.IncludedInstallationStates = $IncludedInstallationState
+                }
+                If ($PSBoundParameters['ExcludedInstallationState']) {
+                    $UpdateScope.ExcludedInstallationStates = $ExcludedInstallationState
+                }
+                If ($PSBoundParameters['UpdateApprovalAction']) {
+                    $UpdateScope.UpdateApprovalActions = $UpdateApprovalAction
+                }
+                If ($PSBoundParameters['UpdateSource']) {
+                    $UpdateScope.UpdateSources = $UpdateSource
+                }
+                If ($PSBoundParameters['UpdateType']) {
+                    $UpdateScope.UpdateTypes = $UpdateType
+                }
+                If ($PSBoundParameters['FromArrivalDate']) {
+                    $UpdateScope.FromArrivalDate = $FromArrivalDate
+                }
+                If ($PSBoundParameters['ToArrivalDate']) {
+                    $UpdateScope.ToArrivalDate = $ToArrivalDate
+                }
+                If ($PSBoundParameters['FromCreationDate']) {
+                    $UpdateScope.FromCreationDate = $FromCreationDate
+                }
+                If ($PSBoundParameters['ToCreationDate']) {
+                    $UpdateScope.ToCreationDate = $ToCreationDate
+                }
+                If ($PSBoundParameters['ExcludeOptionalUpdates']) {
+                    $UpdateScope.ExcludeOptionalUpdates = $ExcludeOptionalUpdates
+                }
+                If ($PSBoundParameters['IsWsusInfrastructureUpdate']) {
+                    $UpdateScope.IsWsusInfrastructureUpdate = $IsWsusInfrastructureUpdate
+                }
+                If ($PSBoundParameters['Category']) {
+                    [void]$UpdateScope.Categories.AddRange($Category)
+                }
+                If ($PSBoundParameters['Classification']) {
+                    [void]$UpdateScope.Classifications.AddRange($Classification)
+                }
+                If ($PSBoundParameters['IncludeText']) {
+                    $UpdateScope.TextIncludes = $IncludeText
+                }
+                If ($PSBoundParameters['ExcludeText']) {
+                    $UpdateScope.TextNotIncludes = $ExcludeText
+                }
+                If ($PSBoundParameters['ComputerTargetGroups']) {
+                    $Groups = @{}
+                    $Wsus.GetComputerTargetGroups() | ForEach {                    
+                        $Groups[$_.Name]=$_
+                    }
+                    ForEach ($Group in $ComputerTargetGroups) {
+                        Write-Verbose "Adding Target Group: $($Group)"
+                        [void]$UpdateScope.ApprovedComputerTargetGroups.Add($Groups[$Group])
+                    }
                 }
             }
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
         }
     }
     Process {

--- a/Scripts/Get-PSWSUSUpdate.ps1
+++ b/Scripts/Get-PSWSUSUpdate.ps1
@@ -214,7 +214,7 @@ function Get-PSWSUSUpdate {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSUpdateApproval.ps1
+++ b/Scripts/Get-PSWSUSUpdateApproval.ps1
@@ -211,7 +211,7 @@ function Get-PSWSUSUpdateApproval {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSUpdateApproval.ps1
+++ b/Scripts/Get-PSWSUSUpdateApproval.ps1
@@ -141,70 +141,79 @@ function Get-PSWSUSUpdateApproval {
         [Parameter(ParameterSetName='UpdateScope')]
         [Microsoft.UpdateServices.Internal.BaseApi.UpdateClassification[]]$Classification                                                                                       
     )
+
     Begin {                
-        $ErrorActionPreference = 'stop'
-        If ($PSCmdlet.ParameterSetName -eq 'UpdateScope') {
-            $UpdateScope = New-Object Microsoft.UpdateServices.Administration.UpdateScope  
-            If ($PSBoundParameters['ApprovedState']) {
-                $UpdateScope.ApprovedStates = $ApprovedState
-            }
-            If ($PSBoundParameters['IncludedInstallationState']) {
-                $UpdateScope.IncludedInstallationStates = $IncludedInstallationState
-            }
-            If ($PSBoundParameters['ExcludedInstallState']) {
-                $UpdateScope.ExcludedInstallStates = $ExcludedInstallState
-            }
-            If ($PSBoundParameters['UpdateApprovalAction']) {
-                $UpdateScope.UpdateApprovalActions = $UpdateApprovalAction
-            }
-            If ($PSBoundParameters['UpdateSource']) {
-                $UpdateScope.UpdateSources = $UpdateSource
-            }
-            If ($PSBoundParameters['UpdateType']) {
-                $UpdateScope.UpdateTypes = $UpdateType
-            }
-            If ($PSBoundParameters['FromArrivalDate']) {
-                $UpdateScope.FromArrivalDate = $FromArrivalDate
-            }
-            If ($PSBoundParameters['ToArrivalDate']) {
-                $UpdateScope.ToArrivalDate = $ToArrivalDate
-            }
-            If ($PSBoundParameters['FromCreationDate']) {
-                $UpdateScope.FromCreationDate = $FromCreationDate
-            }
-            If ($PSBoundParameters['ToCreationDate']) {
-                $UpdateScope.ToCreationDate = $ToCreationDate
-            }
-            If ($PSBoundParameters['ExcludeOptionalUpdates']) {
-                $UpdateScope.ExcludeOptionalUpdates = $ExcludeOptionalUpdates
-            }
-            If ($PSBoundParameters['IsWsusInfrastructureUpdate']) {
-                $UpdateScope.IsWsusInfrastructureUpdate = $IsWsusInfrastructureUpdate
-            }
-            If ($PSBoundParameters['Category']) {
-                [void]$UpdateScope.Categories.AddRange($Category)
-            }
-            If ($PSBoundParameters['Classification']) {
-                [void]$UpdateScope.Classifications.AddRange($Classification)
-            }
-            If ($PSBoundParameters['IncludeText']) {
-                $UpdateScope.TextIncludes = $IncludeText
-            }
-            If ($PSBoundParameters['ExcludeText']) {
-                $UpdateScope.TextNotIncludes = $ExcludeText
-            }
-            If ($PSBoundParameters['ComputerTargetGroups']) {
-                $Groups = @{}
-                $Wsus.GetComputerTargetGroups() | ForEach {                    
-                    $Groups[$_.Name]=$_
+        if($wsus)
+        {
+            $ErrorActionPreference = 'stop'
+            If ($PSCmdlet.ParameterSetName -eq 'UpdateScope') {
+                $UpdateScope = New-Object Microsoft.UpdateServices.Administration.UpdateScope  
+                If ($PSBoundParameters['ApprovedState']) {
+                    $UpdateScope.ApprovedStates = $ApprovedState
                 }
-                ForEach ($Group in $ComputerTargetGroups) {
-                    Write-Verbose "Adding Target Group: $($Group)"
-                    [void]$UpdateScope.ApprovedComputerTargetGroups.Add($Groups[$Group])
+                If ($PSBoundParameters['IncludedInstallationState']) {
+                    $UpdateScope.IncludedInstallationStates = $IncludedInstallationState
+                }
+                If ($PSBoundParameters['ExcludedInstallState']) {
+                    $UpdateScope.ExcludedInstallStates = $ExcludedInstallState
+                }
+                If ($PSBoundParameters['UpdateApprovalAction']) {
+                    $UpdateScope.UpdateApprovalActions = $UpdateApprovalAction
+                }
+                If ($PSBoundParameters['UpdateSource']) {
+                    $UpdateScope.UpdateSources = $UpdateSource
+                }
+                If ($PSBoundParameters['UpdateType']) {
+                    $UpdateScope.UpdateTypes = $UpdateType
+                }
+                If ($PSBoundParameters['FromArrivalDate']) {
+                    $UpdateScope.FromArrivalDate = $FromArrivalDate
+                }
+                If ($PSBoundParameters['ToArrivalDate']) {
+                    $UpdateScope.ToArrivalDate = $ToArrivalDate
+                }
+                If ($PSBoundParameters['FromCreationDate']) {
+                    $UpdateScope.FromCreationDate = $FromCreationDate
+                }
+                If ($PSBoundParameters['ToCreationDate']) {
+                    $UpdateScope.ToCreationDate = $ToCreationDate
+                }
+                If ($PSBoundParameters['ExcludeOptionalUpdates']) {
+                    $UpdateScope.ExcludeOptionalUpdates = $ExcludeOptionalUpdates
+                }
+                If ($PSBoundParameters['IsWsusInfrastructureUpdate']) {
+                    $UpdateScope.IsWsusInfrastructureUpdate = $IsWsusInfrastructureUpdate
+                }
+                If ($PSBoundParameters['Category']) {
+                    [void]$UpdateScope.Categories.AddRange($Category)
+                }
+                If ($PSBoundParameters['Classification']) {
+                    [void]$UpdateScope.Classifications.AddRange($Classification)
+                }
+                If ($PSBoundParameters['IncludeText']) {
+                    $UpdateScope.TextIncludes = $IncludeText
+                }
+                If ($PSBoundParameters['ExcludeText']) {
+                    $UpdateScope.TextNotIncludes = $ExcludeText
+                }
+                If ($PSBoundParameters['ComputerTargetGroups']) {
+                    $Groups = @{}
+                    $Wsus.GetComputerTargetGroups() | ForEach {                    
+                        $Groups[$_.Name]=$_
+                    }
+                    ForEach ($Group in $ComputerTargetGroups) {
+                        Write-Verbose "Adding Target Group: $($Group)"
+                        [void]$UpdateScope.ApprovedComputerTargetGroups.Add($Groups[$Group])
+                    }
                 }
             }
+            Write-Verbose "ParameterSetName: $($PSCmdlet.ParameterSetName)"
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
         }
-        Write-Verbose "ParameterSetName: $($PSCmdlet.ParameterSetName)"
     }
     Process {
         Switch ($PSCmdlet.ParameterSetName) {

--- a/Scripts/Get-PSWSUSUpdateCategory.ps1
+++ b/Scripts/Get-PSWSUSUpdateCategory.ps1
@@ -39,6 +39,14 @@ function Get-PSWSUSUpdateCategory {
             ValueFromPipeline = $True)]
             [string]$Title            
     ) 
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         If ($PSBoundParameters['Id']) {
             $Wsus.GetUpdateCategory($Id)

--- a/Scripts/Get-PSWSUSUpdateCategory.ps1
+++ b/Scripts/Get-PSWSUSUpdateCategory.ps1
@@ -43,7 +43,7 @@ function Get-PSWSUSUpdateCategory {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSUpdateClassification.ps1
+++ b/Scripts/Get-PSWSUSUpdateClassification.ps1
@@ -27,7 +27,7 @@ Function Get-PSWSUSUpdateClassification {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSUpdateClassification.ps1
+++ b/Scripts/Get-PSWSUSUpdateClassification.ps1
@@ -23,6 +23,14 @@ Function Get-PSWSUSUpdateClassification {
     #> 
     [cmdletbinding()]  
     Param()
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         $wsus.GetUpdateClassifications()        
     }

--- a/Scripts/Get-PSWSUSUpdateFile.ps1
+++ b/Scripts/Get-PSWSUSUpdateFile.ps1
@@ -123,22 +123,30 @@ function Get-PSWSUSUpdateFile {
                 }   
             }                
             "name" {
-                Write-Verbose "Using 'Update Name' set name"
-                #Search for updates
-                Write-Verbose "Searching for update/s"
-                $patches = @($wsus.SearchUpdates($UpdateName))
-                If ($patches -eq 0) {
-                    Write-Error "Update $update could not be found in WSUS!"
+                if($wsus)
+                {
+                    Write-Verbose "Using 'Update Name' set name"
+                    #Search for updates
+                    Write-Verbose "Searching for update/s"
+                    $patches = @($wsus.SearchUpdates($UpdateName))
+                    If ($patches -eq 0) {
+                        Write-Error "Update $update could not be found in WSUS!"
+                        Break
+                    } Else {
+                        $Items = $patches | ForEach {
+                            $Patch = $_
+                            Write-Verbose ("Adding NoteProperty for {0}" -f $_.Title)                    
+                            $_.GetInstallableItems() | ForEach {
+                                $itemdata = $_ | Add-Member -MemberType NoteProperty -Name KnowledgeBaseArticles -value $patch.KnowledgeBaseArticles -PassThru
+                                $itemdata | Add-Member -MemberType NoteProperty -Name Title -value $patch.Title -PassThru
+                            }
+                        }                
+                    }
+                }#endif
+                else
+                {
+                    Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
                     Break
-                } Else {
-                    $Items = $patches | ForEach {
-                        $Patch = $_
-                        Write-Verbose ("Adding NoteProperty for {0}" -f $_.Title)                    
-                        $_.GetInstallableItems() | ForEach {
-                            $itemdata = $_ | Add-Member -MemberType NoteProperty -Name KnowledgeBaseArticles -value $patch.KnowledgeBaseArticles -PassThru
-                            $itemdata | Add-Member -MemberType NoteProperty -Name Title -value $patch.Title -PassThru
-                        }
-                    }                
                 }                     
             }
             Default {

--- a/Scripts/Get-PSWSUSUpdateFile.ps1
+++ b/Scripts/Get-PSWSUSUpdateFile.ps1
@@ -145,7 +145,7 @@ function Get-PSWSUSUpdateFile {
                 }#endif
                 else
                 {
-                    Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+                    Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
                     Break
                 }                     
             }

--- a/Scripts/Get-PSWSUSUpdateFiles.ps1
+++ b/Scripts/Get-PSWSUSUpdateFiles.ps1
@@ -35,7 +35,7 @@ function Get-PSWSUSUpdateFiles {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSUpdateSource.ps1
+++ b/Scripts/Get-PSWSUSUpdateSource.ps1
@@ -32,7 +32,7 @@ function Get-PSWSUSUpdateSource {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Get-PSWSUSUpdateSummaryPerClient.ps1
+++ b/Scripts/Get-PSWSUSUpdateSummaryPerClient.ps1
@@ -52,8 +52,16 @@ function Get-PSWSUSUpdateSummaryPerClient {
         [Microsoft.UpdateServices.Administration.UpdateScope]$UpdateScope                                                                                          
     )
     Begin {                
-        $ErrorActionPreference = 'stop'
-        $hash = @{}
+        if($wsus)
+        {
+            $ErrorActionPreference = 'stop'
+            $hash = @{}
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
     }
     Process {
         If ($PSBoundParameters['UpdateScope']) {

--- a/Scripts/Get-PSWSUSUpdateSummaryPerClient.ps1
+++ b/Scripts/Get-PSWSUSUpdateSummaryPerClient.ps1
@@ -59,7 +59,7 @@ function Get-PSWSUSUpdateSummaryPerClient {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Import-PSWSUSMetaData.ps1
+++ b/Scripts/Import-PSWSUSMetaData.ps1
@@ -38,6 +38,14 @@ function Import-PSWSUSMetaData {
             [Parameter(Mandatory=$True,Position = 1,ValueFromPipeline = $True)]
             [string]$LogName                                                            
         )
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         If ($pscmdlet.ShouldProcess($FileName,"Import MetaData")) {
             Try {

--- a/Scripts/Import-PSWSUSMetaData.ps1
+++ b/Scripts/Import-PSWSUSMetaData.ps1
@@ -42,7 +42,7 @@ function Import-PSWSUSMetaData {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/New-PSWSUSGroup.ps1
+++ b/Scripts/New-PSWSUSGroup.ps1
@@ -63,7 +63,7 @@ function New-PSWSUSGroup {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/New-PSWSUSGroup.ps1
+++ b/Scripts/New-PSWSUSGroup.ps1
@@ -59,6 +59,14 @@ function New-PSWSUSGroup {
             Position = 2)]
             [switch]$PassThru                                                            
     ) 
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         Try {
             #Determine action based on Parameter Set Name

--- a/Scripts/Remove-PSWSUSClientFromGroup.ps1
+++ b/Scripts/Remove-PSWSUSClientFromGroup.ps1
@@ -46,6 +46,13 @@ function Remove-PSWSUSClientFromGroup {
                 ValueFromPipeline = $True)]
                 [string]$Computer                                             
                 )
+    
+    if(-not $wsus)
+    {
+        Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+        Break
+    }
+    
     #Verify Computer is in WSUS
     $client = Get-PSWSUSClient -computername $computer
     If ($client) {

--- a/Scripts/Remove-PSWSUSClientFromGroup.ps1
+++ b/Scripts/Remove-PSWSUSClientFromGroup.ps1
@@ -49,7 +49,7 @@ function Remove-PSWSUSClientFromGroup {
     
     if(-not $wsus)
     {
-        Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+        Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
         Break
     }
     

--- a/Scripts/Remove-PSWSUSGroup.ps1
+++ b/Scripts/Remove-PSWSUSGroup.ps1
@@ -56,6 +56,14 @@ function Remove-PSWSUSGroup {
             )]
             [Microsoft.UpdateServices.Internal.BaseApi.ComputerTargetGroup]$InputObject
         )            
+    
+    Begin {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         #Determine action based on Parameter Set Name
         Switch ($pscmdlet.ParameterSetName) {            

--- a/Scripts/Remove-PSWSUSGroup.ps1
+++ b/Scripts/Remove-PSWSUSGroup.ps1
@@ -60,7 +60,7 @@ function Remove-PSWSUSGroup {
     Begin {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Remove-PSWSUSInstallApprovalRule.ps1
+++ b/Scripts/Remove-PSWSUSInstallApprovalRule.ps1
@@ -53,7 +53,7 @@ Function Remove-PSWSUSInstallApprovalRule {
     {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Remove-PSWSUSInstallApprovalRule.ps1
+++ b/Scripts/Remove-PSWSUSInstallApprovalRule.ps1
@@ -48,6 +48,15 @@ Function Remove-PSWSUSInstallApprovalRule {
                 ValueFromPipeline = $True)]
                 [system.object]$InputObject                                                                                                                                
                 )
+    
+    Begin
+    {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         Switch ($pscmdlet.parametersetname) {
             Name {

--- a/Scripts/Remove-PSWSUSUpdate.ps1
+++ b/Scripts/Remove-PSWSUSUpdate.ps1
@@ -42,9 +42,17 @@ function Remove-PSWSUSUpdate {
                 [string]$Update                                          
                 ) 
     Begin {
-        #Gather all updates from given information
-        Write-Verbose "Searching for updates"
-        $patches = $wsus.SearchUpdates($update)
+        if($wsus)
+        {
+            #Gather all updates from given information
+            Write-Verbose "Searching for updates"
+            $patches = $wsus.SearchUpdates($update)
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
     }            
     Process {
         ForEach ($patch in $patches) {

--- a/Scripts/Remove-PSWSUSUpdate.ps1
+++ b/Scripts/Remove-PSWSUSUpdate.ps1
@@ -50,7 +50,7 @@ function Remove-PSWSUSUpdate {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }            

--- a/Scripts/Reset-PSWSUSContent.ps1
+++ b/Scripts/Reset-PSWSUSContent.ps1
@@ -26,7 +26,7 @@ function Reset-PSWSUSContent {
     {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Reset-PSWSUSContent.ps1
+++ b/Scripts/Reset-PSWSUSContent.ps1
@@ -21,6 +21,15 @@ function Reset-PSWSUSContent {
     #> 
     [cmdletbinding()]  
     Param () 
+    
+    Begin
+    {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         #Reset the WSUS content and verify files   
         $wsus.ResetAndVerifyContentState()

--- a/Scripts/Resume-PSWSUSDownload.ps1
+++ b/Scripts/Resume-PSWSUSDownload.ps1
@@ -26,7 +26,7 @@ function Resume-PSWSUSDownload {
     {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Resume-PSWSUSDownload.ps1
+++ b/Scripts/Resume-PSWSUSDownload.ps1
@@ -21,6 +21,15 @@ function Resume-PSWSUSDownload {
     #> 
     [cmdletbinding()]
         Param() 
+    
+    Begin
+    {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {    
         #Resume all downloads running on WSUS       
         If ($pscmdlet.ShouldProcess($($wsus.name))) {

--- a/Scripts/Resume-PSWSUSUpdateDownload.ps1
+++ b/Scripts/Resume-PSWSUSUpdateDownload.ps1
@@ -35,7 +35,15 @@ function Resume-PSWSUSUpdateDownload {
     [switch]$AllUpdates                                          
     ) 
     Begin {
-        $List = New-Object System.Collections.ArrayList
+        if($wsus)
+        {
+            $List = New-Object System.Collections.ArrayList
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
     }                
     Process {
         If ($pscmdlet.ParameterSetName -eq 'Update') {

--- a/Scripts/Resume-PSWSUSUpdateDownload.ps1
+++ b/Scripts/Resume-PSWSUSUpdateDownload.ps1
@@ -41,7 +41,7 @@ function Resume-PSWSUSUpdateDownload {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }                

--- a/Scripts/Set-PSWSUSClassification.ps1
+++ b/Scripts/Set-PSWSUSClassification.ps1
@@ -81,7 +81,7 @@ function Set-PoshWsusClassification {
         }
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Set-PSWSUSConfigEnabledUpdateLanguages.ps1
+++ b/Scripts/Set-PSWSUSConfigEnabledUpdateLanguages.ps1
@@ -54,7 +54,7 @@ function Set-PSWSUSConfigEnabledUpdateLanguages {
     {
         if(-NOT $wsus)
         {
-            Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
 

--- a/Scripts/Set-PSWSUSConfigProduct.ps1
+++ b/Scripts/Set-PSWSUSConfigProduct.ps1
@@ -69,7 +69,7 @@ function Set-PSWSUSConfigProduct {
     {
         if (-NOT $wsus)
         {
-            Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server."
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server."
             Break
         }
         if($PSBoundParameters['Disable'])

--- a/Scripts/Set-PSWSUSConfigProxyServer.ps1
+++ b/Scripts/Set-PSWSUSConfigProxyServer.ps1
@@ -104,7 +104,7 @@ function Set-PSWsusConfigProxyServer {
 
         if(-NOT $wsus)
         {
-            Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
         If ($PSCmdlet.ShouldProcess($wsus.ServerName,'Set Proxy Server')) {

--- a/Scripts/Set-PSWSUSConfigSyncSchedule.ps1
+++ b/Scripts/Set-PSWSUSConfigSyncSchedule.ps1
@@ -71,7 +71,7 @@ function Set-PSWSUSConfigSyncSchedule {
 
     if(-not $wsus)
     {
-        Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+        Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
         Break
     }
     If ($PSCmdlet.ShouldProcess($wsus.ServerName,'Set Sync Schedule')) {

--- a/Scripts/Set-PSWSUSConfigSyncSchedule.ps1
+++ b/Scripts/Set-PSWSUSConfigSyncSchedule.ps1
@@ -69,7 +69,7 @@ function Set-PSWSUSConfigSyncSchedule {
         $NumberOfSynchronizationsPerDay
     )
 
-    if($wsus)
+    if(-not $wsus)
     {
         Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
         Break

--- a/Scripts/Set-PSWSUSConfigTargetingMode.ps1
+++ b/Scripts/Set-PSWSUSConfigTargetingMode.ps1
@@ -53,7 +53,7 @@ function Set-PSWSUSConfigTargetingMode {
     if(-NOT $wsus)
     {
 
-        Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+        Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
         Break
     }
     If ($PSCmdlet.ShouldProcess($wsus.ServerName,'Set Targeting Mode')) {

--- a/Scripts/Set-PSWSUSConfigUpdateClassification.ps1
+++ b/Scripts/Set-PSWSUSConfigUpdateClassification.ps1
@@ -71,7 +71,7 @@ function Set-PSWSUSConfigUpdateClassification {
     {
         if(-NOT $wsus)
         {
-            Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
         if($PSBoundParameters['Disable'])

--- a/Scripts/Set-PSWSUSConfigUpdateFiles.ps1
+++ b/Scripts/Set-PSWSUSConfigUpdateFiles.ps1
@@ -89,7 +89,7 @@ function Set-PSWSUSConfigUpdateFiles {
 
     if(-NOT $wsus)
     {
-        Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+        Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
         Break
     }
        

--- a/Scripts/Set-PSWSUSConfigUpdateSource.ps1
+++ b/Scripts/Set-PSWSUSConfigUpdateSource.ps1
@@ -97,7 +97,7 @@ function Set-PSWSUSConfigUpdateSource {
 
     if(-NOT $wsus)
     {
-        Write-Warning "Use Connect-PSWSUSServer for establish connection with your Windows Update Server"
+        Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
         Break
     }
     If ($PSCmdlet.ShouldProcess($wsus.ServerName,'UpdateConfigSource')) {

--- a/Scripts/Set-PSWSUSEmailConfig.ps1
+++ b/Scripts/Set-PSWSUSEmailConfig.ps1
@@ -125,7 +125,7 @@ function Set-PSWSUSEmailConfig {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Set-PSWSUSEmailConfig.ps1
+++ b/Scripts/Set-PSWSUSEmailConfig.ps1
@@ -117,9 +117,17 @@ function Set-PSWSUSEmailConfig {
             [string]$UpdateServer                                                                                                                                                           
     )
     Begin {   
-        #Configure Email Notifications
-        $email = $wsus.GetEmailNotificationConfiguration()
-        $ErrorActionPreference = 'stop'
+        if($wsus)
+        {
+            #Configure Email Notifications
+            $email = $wsus.GetEmailNotificationConfiguration()
+            $ErrorActionPreference = 'stop'
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
     }
     Process {
         Try {

--- a/Scripts/Set-PSWSUSEnabledUpdateLanguages.ps1
+++ b/Scripts/Set-PSWSUSEnabledUpdateLanguages.ps1
@@ -66,7 +66,7 @@ function Set-PSWSUSEnabledUpdateLanguages {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }#endelse
     }

--- a/Scripts/Set-PSWSUSInstallApprovalRule.ps1
+++ b/Scripts/Set-PSWSUSInstallApprovalRule.ps1
@@ -115,7 +115,7 @@ Function Set-PSWSUSInstallApprovalRule {
     {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Set-PSWSUSInstallApprovalRule.ps1
+++ b/Scripts/Set-PSWSUSInstallApprovalRule.ps1
@@ -109,8 +109,16 @@ Function Set-PSWSUSInstallApprovalRule {
         [Switch]$Disable,
         [Parameter(Position=7)]
         [Switch]$PassThru
-                                                                                                                                         
     )
+
+    Begin
+    {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         If ($pscmdlet.parametersetname -eq "Name") {
             #Locate rule by name

--- a/Scripts/Set-PSWSUSProduct.ps1
+++ b/Scripts/Set-PSWSUSProduct.ps1
@@ -78,7 +78,7 @@ function Set-PoshWSUSProduct {
         }
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server."
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server."
             Break
         }
 

--- a/Scripts/Set-PSWSUSProxyServer.ps1
+++ b/Scripts/Set-PSWSUSProxyServer.ps1
@@ -97,7 +97,7 @@ function Set-PSWSUSProxyServer {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Set-PSWSUSSyncSchedule.ps1
+++ b/Scripts/Set-PSWSUSSyncSchedule.ps1
@@ -73,7 +73,7 @@ function Set-PSWSUSSyncSchedule {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Set-PSWSUSTargetingMode.ps1
+++ b/Scripts/Set-PSWSUSTargetingMode.ps1
@@ -52,7 +52,7 @@ function Set-PSWSUSTargetingMode {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Set-PSWSUSUpdateFiles.ps1
+++ b/Scripts/Set-PSWSUSUpdateFiles.ps1
@@ -93,7 +93,7 @@ function Set-PSWSUSUpdateFiles {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Set-PSWSUSUpdateSource.ps1
+++ b/Scripts/Set-PSWSUSUpdateSource.ps1
@@ -104,7 +104,7 @@ function Set-PSWSUSUpdateSource {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Start-PSWSUSCleanup.ps1
+++ b/Scripts/Start-PSWSUSCleanup.ps1
@@ -76,30 +76,39 @@ function Start-PSWSUSCleanup {
                 Position = 5)]
                 [switch]$CleanupUnneededContentFiles                                                                                                     
                 ) 
+    
     Begin {            
-        #Create cleanup scope
-        $cleanScope = new-object Microsoft.UpdateServices.Administration.CleanupScope
-        #Create cleanup manager object
-        $cleanup = $wsus.GetCleanupManager()
+        if($wsus)
+        {
+            #Create cleanup scope
+            $cleanScope = new-object Microsoft.UpdateServices.Administration.CleanupScope
+            #Create cleanup manager object
+            $cleanup = $wsus.GetCleanupManager()
 
-        #Determine what will be in the scope
-        If ($PSBoundParameters['DeclineSupersededUpdates']) {
-            $cleanScope.DeclineSupersededUpdates = $True
-        }
-        If ($PSBoundParameters['DeclineExpiredUpdates']) {
-            $cleanScope.DeclineExpiredUpdates = $True
-        }
-        If ($PSBoundParameters['CleanupObsoleteUpdates']) {
-            $cleanScope.CleanupObsoleteUpdates = $True
-        }        
-        If ($PSBoundParameters['CompressUpdates']) {
-            $cleanScope.CompressUpdates = $True
-        }
-        If ($PSBoundParameters['CleanupObsoleteComputers']) {
-            $cleanScope.CleanupObsoleteComputers = $True
-        }
-        If ($PSBoundParameters['CleanupUnneededContentFiles']) {
-            $cleanScope.CleanupUnneededContentFiles = $True
+            #Determine what will be in the scope
+            If ($PSBoundParameters['DeclineSupersededUpdates']) {
+                $cleanScope.DeclineSupersededUpdates = $True
+            }
+            If ($PSBoundParameters['DeclineExpiredUpdates']) {
+                $cleanScope.DeclineExpiredUpdates = $True
+            }
+            If ($PSBoundParameters['CleanupObsoleteUpdates']) {
+                $cleanScope.CleanupObsoleteUpdates = $True
+            }        
+            If ($PSBoundParameters['CompressUpdates']) {
+                $cleanScope.CompressUpdates = $True
+            }
+            If ($PSBoundParameters['CleanupObsoleteComputers']) {
+                $cleanScope.CleanupObsoleteComputers = $True
+            }
+            If ($PSBoundParameters['CleanupUnneededContentFiles']) {
+                $cleanScope.CleanupUnneededContentFiles = $True
+            }
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
         }
     }
     Process {

--- a/Scripts/Start-PSWSUSCleanup.ps1
+++ b/Scripts/Start-PSWSUSCleanup.ps1
@@ -107,7 +107,7 @@ function Start-PSWSUSCleanup {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Start-PSWSUSInstallApprovalRule.ps1
+++ b/Scripts/Start-PSWSUSInstallApprovalRule.ps1
@@ -54,7 +54,7 @@ Function Start-PSWSUSInstallApprovalRule {
     {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Start-PSWSUSInstallApprovalRule.ps1
+++ b/Scripts/Start-PSWSUSInstallApprovalRule.ps1
@@ -49,6 +49,15 @@ Function Start-PSWSUSInstallApprovalRule {
                 ValueFromPipeline = $True)]
                 [system.object]$InputObject                                                                                                                                
                 )
+    
+    Begin
+    {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process {
         Switch ($pscmdlet.parametersetname) {
             Name {

--- a/Scripts/Start-PSWSUSSync.ps1
+++ b/Scripts/Start-PSWSUSSync.ps1
@@ -36,7 +36,7 @@ function Start-PSWSUSSync {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }  
     }

--- a/Scripts/Start-PSWSUSSync.ps1
+++ b/Scripts/Start-PSWSUSSync.ps1
@@ -27,9 +27,18 @@ function Start-PSWSUSSync {
         SupportsShouldProcess = $True
     )] 
     Param ()
+    
     Begin {
-        $sub = $wsus.GetSubscription()    
-        $sync = $sub.GetSynchronizationProgress()  
+        if($wsus)
+        {
+            $sub = $wsus.GetSubscription()    
+            $sync = $sub.GetSynchronizationProgress()
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }  
     }
     Process {  
         #Start WSUS synchronization

--- a/Scripts/Stop-PSWSUSDownload.ps1
+++ b/Scripts/Stop-PSWSUSDownload.ps1
@@ -26,7 +26,7 @@ function Stop-PSWSUSDownload {
     {
         if(-not $wsus)
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }

--- a/Scripts/Stop-PSWSUSDownload.ps1
+++ b/Scripts/Stop-PSWSUSDownload.ps1
@@ -21,6 +21,15 @@ function Stop-PSWSUSDownload {
     #> 
     [cmdletbinding()]
     Param()
+    
+    Begin
+    {
+        if(-not $wsus)
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
+    }
     Process { 
         #Cancel all downloads running on WSUS       
         If ($pscmdlet.ShouldProcess($($wsus.name))) {

--- a/Scripts/Stop-PSWSUSSync.ps1
+++ b/Scripts/Stop-PSWSUSSync.ps1
@@ -25,8 +25,17 @@ function Stop-PSWSUSSync {
         SupportsShouldProcess = $True
     )]
         Param()
+    
     Begin {
-        $sub = $wsus.GetSubscription()      
+        if($wsus)
+        {
+            $sub = $wsus.GetSubscription()
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }   
     }
     Process {
         #Cancel synchronization running on WSUS       

--- a/Scripts/Stop-PSWSUSSync.ps1
+++ b/Scripts/Stop-PSWSUSSync.ps1
@@ -33,7 +33,7 @@ function Stop-PSWSUSSync {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }   
     }

--- a/Scripts/Stop-PSWSUSUpdateDownload.ps1
+++ b/Scripts/Stop-PSWSUSUpdateDownload.ps1
@@ -31,10 +31,19 @@ function Stop-PSWSUSUpdateDownload {
                 ValueFromPipeline = $True)]
                 [string]$update                                          
                 ) 
+
     Begin {
-        #Gather all updates from given information
-        Write-Verbose "Searching for updates"
-        $patches = $wsus.SearchUpdates($update)
+        if($wsus)
+        {
+            #Gather all updates from given information
+            Write-Verbose "Searching for updates"
+            $patches = $wsus.SearchUpdates($update)
+        }#endif
+        else
+        {
+            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Break
+        }
     }            
     Process {
         If ($patches) {

--- a/Scripts/Stop-PSWSUSUpdateDownload.ps1
+++ b/Scripts/Stop-PSWSUSUpdateDownload.ps1
@@ -41,7 +41,7 @@ function Stop-PSWSUSUpdateDownload {
         }#endif
         else
         {
-            Write-Warning "Use Connect-PoshWSUSServer for establish connection with your Windows Update Server"
+            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
             Break
         }
     }            


### PR DESCRIPTION
Addresses issue #28 

As mentioned in the referenced issue, some functions were warning to run Connect-PSWSUSServer when the $wsus object already existed. I've adjusted these to inverse the logic.

Also took the opportunity to add this check to other functions that called the (potentially) unassigned $wsus variable and run a pass through to pick up any instances of the cmdlet being referred to as "PoshWSUSServer".

I've not altered the structure of the cmdlets, e.g. if there was already a begin block then the check went in there, if there wasn't a begin block but there was a process block I added begin and if there was not begin or process I just added it in the same scope as the rest of the script.