### PR TITLE
Fix for mis-scoped $wsus check

### DIFF
--- a/Scripts/Remove-PSWSUSGroup.ps1
+++ b/Scripts/Remove-PSWSUSGroup.ps1
@@ -57,14 +57,15 @@ function Remove-PSWSUSGroup {
             [Microsoft.UpdateServices.Internal.BaseApi.ComputerTargetGroup]$InputObject
         )            
     
-    Begin {
-        if(-not $wsus)
-        {
-            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
-            Break
-        }
-    }
     Process {
+        if ($pscmdlet.ParameterSetName -ne 'object') {
+            if(-not $wsus)
+            {
+                Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
+                Break
+            }
+        }
+
         #Determine action based on Parameter Set Name
         Switch ($pscmdlet.ParameterSetName) {            
             "name" {

--- a/Scripts/Set-PSWSUSInstallApprovalRule.ps1
+++ b/Scripts/Set-PSWSUSInstallApprovalRule.ps1
@@ -111,24 +111,22 @@ Function Set-PSWSUSInstallApprovalRule {
         [Switch]$PassThru
     )
 
-    Begin
-    {
-        if(-not $wsus)
-        {
-            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
-            Break
-        }
-    }
     Process {
         If ($pscmdlet.parametersetname -eq "Name") {
-            #Locate rule by name
-            Write-Verbose "Locating Rule by name"
-            $rule = $wsus.GetInstallApprovalRules() | Where {
-                $_.Name -eq $name
+            if ($wsus) {
+                #Locate rule by name
+                Write-Verbose "Locating Rule by name"
+                $rule = $wsus.GetInstallApprovalRules() | Where {
+                    $_.Name -eq $name
+                }
+                If ($rule -eq $Null) {
+                    Write-Warning "No rules found by given name"
+                    Continue
+                }
             }
-            If ($rule -eq $Null) {
-                Write-Warning "No rules found by given name"
-                Continue
+            else {
+                Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
+                Break
             }
         } Else {
             #Rule is coming in as an object

--- a/Scripts/Start-PSWSUSInstallApprovalRule.ps1
+++ b/Scripts/Start-PSWSUSInstallApprovalRule.ps1
@@ -50,32 +50,30 @@ Function Start-PSWSUSInstallApprovalRule {
                 [system.object]$InputObject                                                                                                                                
                 )
     
-    Begin
-    {
-        if(-not $wsus)
-        {
-            Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
-            Break
-        }
-    }
     Process {
         Switch ($pscmdlet.parametersetname) {
             Name {
-                #Locate rule by name
-                Write-Verbose "Locating Rule by name"
-                $rule = $wsus.GetInstallApprovalRules() | Where {
-                    $_.Name -eq $name
+                if ($wsus) {
+                    #Locate rule by name
+                    Write-Verbose "Locating Rule by name"
+                    $rule = $wsus.GetInstallApprovalRules() | Where {
+                        $_.Name -eq $name
+                    }
+                    If ($rule -eq $Null) {
+                        Write-Warning "No rules found by given name"
+                        Continue
+                    } Else {
+                        If ($pscmdlet.ShouldProcess("$($rule.name)")) {
+                            #Running approval rule
+                            Write-Verbose "Running approval rule"
+                            $rule.ApplyRule()
+                        }                
+                    }
                 }
-                If ($rule -eq $Null) {
-                    Write-Warning "No rules found by given name"
-                    Continue
-                } Else {
-                    If ($pscmdlet.ShouldProcess("$($rule.name)")) {
-                        #Running approval rule
-                        Write-Verbose "Running approval rule"
-                        $rule.ApplyRule()
-                    }                
-                }                
+                else {
+                    Write-Warning "Use Connect-PSWSUSServer to establish connection with your Windows Update Server"
+                    Break
+                }               
             }
             Object {
                 #Rule is an object


### PR DESCRIPTION
I mis-scoped the $wsus check in a couple of function that can *technially* complete without the connection, specifically those that accept a fully formed object and don't need the $wsus variable to 'find' the object by name.

This commit adjusts this so that the functions in question can complete as expected.